### PR TITLE
[Breaking Change] Add fields to `Dn`& `ReservedRec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/noonchen/rust-stdf"
 documentation = "https://docs.rs/rust-stdf/"
 readme = "README.md"
 license = "MIT"
-version = "0.4.1"
+version = "1.0.0"
 edition = "2021"
 keywords = ["stdf", "atdf", "semiconductor", "parse"]
 exclude = ["/demo_stdf"]
@@ -20,7 +20,7 @@ lto = "fat"
 codegen-units = 1
 
 [dependencies]
-rust-stdf-derive = { path = "derive", version = "0.4.1" }
+rust-stdf-derive = { path = "derive", version = "1.0.0" }
 smart-default = "0.6.0"
 flate2 = { version = "1.1.9", optional = true}
 bzip2 = { version = "0.6.1", optional = true}

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-stdf-derive"
-version = "0.4.1"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 description = "Internal derive macros for the rust-stdf crate (STDF record codec + zero-copy views)."

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1232,7 +1232,7 @@ pub fn stdf_records(input: TokenStream) -> TokenStream {
                 // rec type 180: Reserved
                 // rec type 181: Reserved
                 pub const REC_RESERVE: u64 = 1u64 << #reserve_bit;
-                pub const REC_INVALID: u64 = 1u64 << #invalid_bit;
+                pub const REC_UNKNOWN: u64 = 1u64 << #invalid_bit;
             }
             .into()
         }
@@ -1275,7 +1275,7 @@ pub fn stdf_records(input: TokenStream) -> TokenStream {
                     // rec type 180: Reserved
                     // rec type 181: Reserved
                     ReservedRec(ReservedRec),
-                    InvalidRec(RecordHeader),
+                    UnknownRec(ReservedRec),
                 }
 
                 /// Zero-copy view over the field data of a single STDF record.
@@ -1295,8 +1295,8 @@ pub fn stdf_records(input: TokenStream) -> TokenStream {
                     #( #view_variants, )*
                     // rec type 180: Reserved
                     // rec type 181: Reserved
-                    ReservedRec { raw_data: &'a [u8] },
-                    InvalidRec(RecordHeader),
+                    ReservedRec(ReservedRecView<'a>),
+                    UnknownRec(ReservedRecView<'a>),
                 }
             }
             .into()
@@ -1340,7 +1340,7 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                 // rec type 181: Reserved
                 (180 | 181, _) => REC_RESERVE,
                 // not matched
-                _ => REC_INVALID,
+                _ => REC_UNKNOWN,
             }
         },
         "name_from_code" => quote! {
@@ -1350,13 +1350,14 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                 // rec type 181: Reserved
                 REC_RESERVE => "ReservedRec",
                 // not matched
-                _ => "InvalidRec",
+                _ => "UnknownRec",
             }
         },
         "code_from_name" => quote! {
             match rec_name {
                 #( #lits => #codes, )*
-                _ => REC_INVALID,
+                "ReservedRec" => REC_RESERVE,
+                _ => REC_UNKNOWN,
             }
         },
 
@@ -1366,7 +1367,7 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                 #( #qcodes => StdfRecord::#names(#names::new()), )*
                 stdf_record_type::REC_RESERVE => StdfRecord::ReservedRec(ReservedRec::new()),
                 // not matched
-                _ => StdfRecord::InvalidRec(RecordHeader::new()),
+                _ => StdfRecord::UnknownRec(ReservedRec::new()),
             }
         },
         "record_type" => quote! {
@@ -1376,7 +1377,7 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                 // rec type 181: Reserved
                 StdfRecord::ReservedRec(_) => stdf_record_type::REC_RESERVE,
                 // not matched
-                StdfRecord::InvalidRec(_) => stdf_record_type::REC_INVALID,
+                StdfRecord::UnknownRec(_) => stdf_record_type::REC_UNKNOWN,
             }
         },
         "record_read" => {
@@ -1397,8 +1398,8 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                     // rec type 180: Reserved
                     // rec type 181: Reserved
                     StdfRecord::ReservedRec(rec) => rec.read_from_bytes(raw_data, order),
-                    // not matched, invalid rec do not parse anything
-                    StdfRecord::InvalidRec(_) => (),
+                    // not matched
+                    StdfRecord::UnknownRec(rec) => rec.read_from_bytes(raw_data, order),
                 }
             }
         }
@@ -1421,9 +1422,19 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                     #( #arms, )*
                     // rec type 180: Reserved
                     // rec type 181: Reserved
-                    stdf_record_type::REC_RESERVE => StdfRecordView::ReservedRec { raw_data },
+                    stdf_record_type::REC_RESERVE => StdfRecordView::ReservedRec(ReservedRecView {
+                        typ: header.typ,
+                        sub: header.sub,
+                        byte_order: *byte_order,
+                        raw_data,
+                    }),
                     // not matched
-                    _ => StdfRecordView::InvalidRec(header),
+                    _ => StdfRecordView::UnknownRec(ReservedRecView {
+                        typ: header.typ,
+                        sub: header.sub,
+                        byte_order: *byte_order,
+                        raw_data,
+                    }),
                 }
             }
         }
@@ -1445,9 +1456,9 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                     #( #arms, )*
                     // rec type 180: Reserved
                     // rec type 181: Reserved
-                    StdfRecordView::ReservedRec { .. } => stdf_record_type::REC_RESERVE,
+                    StdfRecordView::ReservedRec(_) => stdf_record_type::REC_RESERVE,
                     // not matched
-                    StdfRecordView::InvalidRec(_) => stdf_record_type::REC_INVALID,
+                    StdfRecordView::UnknownRec(_) => stdf_record_type::REC_UNKNOWN,
                 }
             }
         }
@@ -1468,13 +1479,21 @@ pub fn stdf_match_expr(input: TokenStream) -> TokenStream {
                     #( #arms, )*
                     // rec type 180: Reserved
                     // rec type 181: Reserved
-                    StdfRecordView::ReservedRec { raw_data } => {
+                    StdfRecordView::ReservedRec(v) => {
                         let mut rec = ReservedRec::new();
-                        rec.read_from_bytes(raw_data, &ByteOrder::LittleEndian);
+                        rec.typ = v.typ;
+                        rec.sub = v.sub;
+                        rec.read_from_bytes(v.raw_data, &v.byte_order);
                         StdfRecord::ReservedRec(rec)
                     }
                     // not matched
-                    StdfRecordView::InvalidRec(h) => StdfRecord::InvalidRec(*h),
+                    StdfRecordView::UnknownRec(v) => {
+                        let mut rec = ReservedRec::new();
+                        rec.typ = v.typ;
+                        rec.sub = v.sub;
+                        rec.read_from_bytes(v.raw_data, &v.byte_order);
+                        StdfRecord::UnknownRec(rec)
+                    },
                 }
             }
         }

--- a/example/stdf_to_xlsx.rs
+++ b/example/stdf_to_xlsx.rs
@@ -53,9 +53,9 @@ fn main() -> Result<(), XlsxError> {
         // if file is abnormally truncated, the last
         // `stdf_rec` will be an error.
         //
-        // Invalid record in the middle of file stream
+        // Unknown record in the middle of file stream
         // will not throw error, instead returning a
-        // `StdfRecord::InvalidRec`.
+        // `StdfRecord::UnknownRec`.
         let stdf_rec = stdf_rec.unwrap();
         // use record name as hashmap key
         let rec_name = get_rec_name_from_code(stdf_rec.get_type());
@@ -223,8 +223,8 @@ fn main() -> Result<(), XlsxError> {
                 let json = serde_json::to_value(&r).unwrap();
                 write_json_to_sheet(json, field_names, sheet, row)?;
             }
-            StdfRecord::InvalidRec(h) => {
-                panic!("Invalid record found! {h:?}")
+            StdfRecord::UnknownRec(r) => {
+                panic!("Unknown record found! {r:?}")
             }
         }
     }

--- a/src/atdf_types.rs
+++ b/src/atdf_types.rs
@@ -359,7 +359,7 @@ impl AtdfRecord {
         // do some ATDF syntax checking here, start parsing ATDF rec
         let (rec_name, rec_data) = atdf_str.split_once(':').unwrap_or(("", atdf_str));
         let type_code = get_code_from_rec_name(rec_name);
-        if type_code == REC_INVALID {
+        if type_code == REC_UNKNOWN {
             return Err(StdfError::new(
                 StdfErrorKind::InvalidRecordType,
                 format!(
@@ -654,8 +654,8 @@ impl From<&StdfRecord> for AtdfRecord {
             // rec type 181: Reserved
             // not matched
             _ => {
-                type_code = REC_INVALID;
-                rec_name = "INVALID".to_string();
+                type_code = REC_UNKNOWN;
+                rec_name = "UNKNOWN".to_string();
                 atdf_fields = &INVALID_FIELD;
                 data_list = vec![];
             }

--- a/src/atdf_types.rs
+++ b/src/atdf_types.rs
@@ -914,28 +914,28 @@ pub(crate) fn atdf_data_from_ftr(rec: &FTR) -> Vec<String> {
         } else {
             "F".to_string()
         },
-        alarm_flags,                     //AlarmFlags
-        rec.vect_nam.clone(),            //VECT_NAM
-        rec.time_set.clone(),            //TIME_SET
-        rec.cycl_cnt.to_string(),        //CYCL_CNT
-        rec.rel_vadr.to_string(),        //REL_VADR
-        rec.rept_cnt.to_string(),        //REPT_CNT
-        rec.num_fail.to_string(),        //NUM_FAIL
-        rec.xfail_ad.to_string(),        //XFAIL_AD
-        rec.yfail_ad.to_string(),        //YFAIL_AD
-        rec.vect_off.to_string(),        //VECT_OFF
-        ser_stdf_kx_data(&rec.rtn_indx), //RTN_INDX
-        ser_kx_digit_hex(&rec.rtn_stat), //RTN_STAT
-        ser_stdf_kx_data(&rec.pgm_indx), //PGM_INDX
-        ser_kx_digit_hex(&rec.pgm_stat), //PGM_STAT
-        ser_stdf_kx_data(&rec.fail_pin), //FAIL_PIN
-        rec.op_code.clone(),             //OP_CODE
-        rec.test_txt.clone(),            //TEST_TXT
-        rec.alarm_id.clone(),            //ALARM_ID
-        rec.prog_txt.clone(),            //PROG_TXT
-        rec.rslt_txt.clone(),            //RSLT_TXT
-        rec.patg_num.to_string(),        //PATG_NUM
-        ser_stdf_kx_data(&rec.spin_map), //SPIN_MAP
+        alarm_flags,                              //AlarmFlags
+        rec.vect_nam.clone(),                     //VECT_NAM
+        rec.time_set.clone(),                     //TIME_SET
+        rec.cycl_cnt.to_string(),                 //CYCL_CNT
+        rec.rel_vadr.to_string(),                 //REL_VADR
+        rec.rept_cnt.to_string(),                 //REPT_CNT
+        rec.num_fail.to_string(),                 //NUM_FAIL
+        rec.xfail_ad.to_string(),                 //XFAIL_AD
+        rec.yfail_ad.to_string(),                 //YFAIL_AD
+        rec.vect_off.to_string(),                 //VECT_OFF
+        ser_stdf_kx_data(&rec.rtn_indx),          //RTN_INDX
+        ser_kx_digit_hex(&rec.rtn_stat),          //RTN_STAT
+        ser_stdf_kx_data(&rec.pgm_indx),          //PGM_INDX
+        ser_kx_digit_hex(&rec.pgm_stat),          //PGM_STAT
+        ser_stdf_kx_data(&rec.fail_pin.bit_data), //FAIL_PIN
+        rec.op_code.clone(),                      //OP_CODE
+        rec.test_txt.clone(),                     //TEST_TXT
+        rec.alarm_id.clone(),                     //ALARM_ID
+        rec.prog_txt.clone(),                     //PROG_TXT
+        rec.rslt_txt.clone(),                     //RSLT_TXT
+        rec.patg_num.to_string(),                 //PATG_NUM
+        ser_stdf_kx_data(&rec.spin_map.bit_data), //SPIN_MAP
     ]
 }
 
@@ -1051,7 +1051,7 @@ pub(crate) fn atdf_data_from_gdr(rec: &GDR) -> Vec<String> {
             V1::R8(r8) => gen_data_list.push(format!("D{}", r8)),
             V1::Cn(cn) => gen_data_list.push(format!("T{}", cn)),
             V1::Bn(bn) => gen_data_list.push(format!("X{}", ser_bn_dn(bn))),
-            V1::Dn(dn) => gen_data_list.push(format!("Y{}", ser_bn_dn(dn))),
+            V1::Dn(dn) => gen_data_list.push(format!("Y{}", ser_bn_dn(&dn.bit_data))),
             V1::N1(n1) => gen_data_list.push(format!("N{}", n1)),
             // No pad bytes in ATDF
             _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,19 +605,28 @@ mod tests {
         let mut pos = 0;
         let order = ByteOrder::LittleEndian;
         assert_eq!(
-            vec![84, 101, 115, 116, 32, 79, 75],
+            Dn {
+                bit_count: 56,
+                bit_data: vec![84, 101, 115, 116, 32, 79, 75],
+            },
             stdf_codec::read_dn(&raw_data, &mut pos, &order)
         );
         assert_eq!(pos, 9);
         let mut pos = 4;
         assert_eq!(
-            vec![32, 79, 75, 0],
+            Dn {
+                bit_count: 0x7473,
+                bit_data: vec![32, 79, 75, 0],
+            },
             stdf_codec::read_dn(&raw_data, &mut pos, &order)
         );
         assert_eq!(pos, 10);
         let mut pos = 100;
         assert_eq!(
-            vec![0u8; 0],
+            Dn {
+                bit_count: 0,
+                bit_data: Vec::new(),
+            },
             stdf_codec::read_dn(&raw_data, &mut pos, &order)
         );
         assert_eq!(pos, 100);

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -279,7 +279,7 @@ impl StdfRecord {
     /// // create a PMR StdfRecord from header
     /// // (1, 60)
     /// let pmr_header = RecordHeader {typ: 1, sub: 60, len: 0 };
-    /// let new_rec = StdfRecord::new_from_header(pmr_header);
+    /// let new_rec = StdfRecord::new_from_header(&pmr_header);
     ///
     /// if let StdfRecord::PMR(pmr_rec) = new_rec {
     ///     assert_eq!(pmr_rec.head_num, 1);
@@ -289,7 +289,7 @@ impl StdfRecord {
     /// }
     /// ```
     #[inline(always)]
-    pub fn new_from_header(header: RecordHeader) -> Self {
+    pub fn new_from_header(header: &RecordHeader) -> Self {
         let code = stdf_record_type::get_code_from_typ_sub(header.typ, header.sub);
         match code {
             stdf_record_type::REC_RESERVE => {
@@ -512,7 +512,7 @@ impl From<&RawDataElement> for StdfRecord {
     /// it will NOT consume the input RawDataElement
     #[inline(always)]
     fn from(raw_element: &RawDataElement) -> Self {
-        let mut rec = StdfRecord::new_from_header(raw_element.header);
+        let mut rec = StdfRecord::new_from_header(&raw_element.header);
         rec.read_from_bytes(&raw_element.raw_data, &raw_element.byte_order);
         rec
     }
@@ -534,7 +534,7 @@ impl From<RawDataElement> for StdfRecord {
     /// it will consume the input RawDataElement
     #[inline(always)]
     fn from(raw_element: RawDataElement) -> Self {
-        let mut rec = StdfRecord::new_from_header(raw_element.header);
+        let mut rec = StdfRecord::new_from_header(&raw_element.header);
         rec.read_from_bytes(&raw_element.raw_data, &raw_element.byte_order);
         rec
     }
@@ -551,7 +551,7 @@ impl From<&RawDataElementView<'_>> for StdfRecord {
     /// Parse the borrowed bytes into an owned record; does not consume the input.
     #[inline(always)]
     fn from(raw_view: &RawDataElementView<'_>) -> Self {
-        let mut rec = StdfRecord::new_from_header(raw_view.header);
+        let mut rec = StdfRecord::new_from_header(&raw_view.header);
         rec.read_from_bytes(raw_view.raw_data, &raw_view.byte_order);
         rec
     }

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -270,7 +270,7 @@ impl StdfRecord {
     /// Create a `StdfRecord` from a `RecordHeader` with default data
     ///
     /// The difference between `new()` is that this method can save
-    /// the info of an invalid record header, help the caller to
+    /// the info of an unknown/reserved record header, help the caller to
     /// debug
     ///
     /// ```
@@ -291,11 +291,20 @@ impl StdfRecord {
     #[inline(always)]
     pub fn new_from_header(header: RecordHeader) -> Self {
         let code = stdf_record_type::get_code_from_typ_sub(header.typ, header.sub);
-        if code == stdf_record_type::REC_INVALID {
-            // Preserve the invalid header so callers can inspect it for debugging.
-            StdfRecord::InvalidRec(header)
-        } else {
-            StdfRecord::new(code)
+        match code {
+            stdf_record_type::REC_RESERVE => {
+                let mut rec = ReservedRec::new();
+                rec.typ = header.typ;
+                rec.sub = header.sub;
+                StdfRecord::ReservedRec(rec)
+            }
+            stdf_record_type::REC_UNKNOWN => {
+                let mut rec = ReservedRec::new();
+                rec.typ = header.typ;
+                rec.sub = header.sub;
+                StdfRecord::UnknownRec(rec)
+            }
+            _ => StdfRecord::new(code),
         }
     }
 
@@ -398,7 +407,7 @@ impl StdfRecord {
         }
 
         let data_slice = &raw_data[4..expected_end_pos];
-        let mut rec = StdfRecord::new(header.get_type());
+        let mut rec = StdfRecord::new_from_header(&header);
         rec.read_from_bytes(data_slice, order);
         Ok(rec)
     }

--- a/src/records/type_180_reserved.rs
+++ b/src/records/type_180_reserved.rs
@@ -14,7 +14,11 @@ use struct_field_names_as_array::FieldNamesAsArray;
 )]
 #[derive(SmartDefault, Debug, Clone, PartialEq, Eq)]
 pub struct ReservedRec {
-    pub raw_data: Vec<u8>, // unparsed data
+    pub typ: u8,
+    pub sub: u8,
+    #[default(ByteOrder::LittleEndian)]
+    pub byte_order: ByteOrder,
+    pub raw_data: Vec<u8>, // unparsed field data
 }
 
 impl ReservedRec {
@@ -22,9 +26,24 @@ impl ReservedRec {
         ReservedRec::default()
     }
 
-    pub fn read_from_bytes(&mut self, raw_data: &[u8], _order: &ByteOrder) {
+    pub fn read_from_bytes(&mut self, raw_data: &[u8], order: &ByteOrder) {
         let mut dataclone = Vec::with_capacity(raw_data.len());
         dataclone.extend_from_slice(raw_data);
         self.raw_data = dataclone;
+        self.byte_order = *order;
     }
+}
+
+/// Borrowed view of a reserved/unknown record.
+///
+/// This is the view-side counterpart of [`ReservedRec`]. It keeps the record
+/// header fields (`typ`/`sub`) and byte order so it can be converted back to an
+/// owned record without losing information needed by a future STDF writer.
+#[derive(SmartDefault, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReservedRecView<'a> {
+    pub typ: u8,
+    pub sub: u8,
+    #[default(ByteOrder::LittleEndian)]
+    pub byte_order: ByteOrder,
+    pub raw_data: &'a [u8],
 }

--- a/src/stdf_codec/primitive_read.rs
+++ b/src/stdf_codec/primitive_read.rs
@@ -160,17 +160,23 @@ pub(crate) fn read_bn(raw_data: &[u8], pos: &mut usize) -> Bn {
 /// Read Dn (u16 + Vec<u8>) from byte array with offset "pos", u16 is bit counts
 #[inline(always)]
 pub(crate) fn read_dn(raw_data: &[u8], pos: &mut usize, order: &ByteOrder) -> Dn {
-    let bitcount = read_u2(raw_data, pos, order) as usize;
-    let bytecount = bitcount.div_ceil(8);
+    let bitcount = read_u2(raw_data, pos, order);
+    let bytecount = (bitcount as usize).div_ceil(8);
     if bytecount != 0 {
         let min_pos = std::cmp::min(*pos + bytecount, raw_data.len());
         let data_slice = &raw_data[*pos..min_pos];
         *pos = min_pos;
         let mut value = vec![0u8; data_slice.len()];
         value.copy_from_slice(data_slice);
-        value
+        Dn {
+            bit_count: bitcount,
+            bit_data: value,
+        }
     } else {
-        vec![0u8; 0]
+        Dn {
+            bit_count: bitcount,
+            bit_data: Vec::new(),
+        }
     }
 }
 

--- a/src/stdf_codec/primitives.rs
+++ b/src/stdf_codec/primitives.rs
@@ -41,20 +41,28 @@ pub type I4 = i32;
 pub type R4 = f32;
 pub type R8 = f64;
 
-// Cn;	//first byte = unsigned count of bytes to follow (maximum of 255 bytes)
+// Variable length character string, first byte = unsigned count of bytes to follow (maximum of 255 bytes)
 pub type Cn = String;
 
 // Variable length character string, string length is stored in another field
 pub type Cf = String;
 
-// first two bytes = unsigned count of bytes to follow (maximum of 65535 bytes)
+// Variable length character string, first two bytes = unsigned count of bytes to follow (maximum of 65535 bytes)
 pub type Sn = String;
 
-// Bn;	//First byte = unsigned count of bytes to follow (maximum of 255 bytes)
+// Variable length byte array, first byte = unsigned count of bytes to follow (maximum of 255 bytes)
 pub type Bn = Vec<u8>;
 
-// Dn;	//First two bytes = unsigned count of bits to follow (maximum of 65,535 bits)
-pub type Dn = Vec<u8>;
+/// Variable length bit array, first two bytes = unsigned count of bits to follow (maximum of 65,535 bits)
+///
+/// `bit_count` is the declared number of bits, and `bit_data` stores the
+/// packed bytes (length should be `ceil(bit_count / 8)`).
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[derive(SmartDefault, Debug, Clone, PartialEq, Eq)]
+pub struct Dn {
+    pub bit_count: u16,
+    pub bit_data: Vec<u8>,
+}
 
 pub type KxCn = Vec<Cn>;
 pub type KxSn = Vec<Sn>;
@@ -141,7 +149,10 @@ pub struct BnRef<'a>(&'a [u8]);
 /// Zero-copy borrow of a `Dn` payload (the bytes *after* the 2-byte,
 /// byte-order-dependent bit-count prefix).
 #[derive(SmartDefault, Clone, Copy, Debug)]
-pub struct DnRef<'a>(&'a [u8]);
+pub struct DnRef<'a> {
+    bit_count: u16,
+    bit_data: &'a [u8],
+}
 
 /// Zero-copy view over the `k` elements of a `KxCn` array (each element is a
 /// 1-byte length prefix followed by the payload).
@@ -344,33 +355,45 @@ impl<'a> DnRef<'a> {
     pub(crate) fn read_at(raw: &'a [u8], off: u16, order: &ByteOrder) -> Option<Self> {
         let p = validate_offset(off)?;
         let mut cp = p;
-        let bitcount = read_u2(raw, &mut cp, order) as usize;
-        let bytecount = bitcount.div_ceil(8);
+        let bitcount = read_u2(raw, &mut cp, order);
+        let bytecount = (bitcount as usize).div_ceil(8);
         let start = cp;
         let end = std::cmp::min(start + bytecount, raw.len());
-        Some(DnRef(raw.get(start..end).unwrap_or(&[])))
+        Some(DnRef {
+            bit_count: bitcount,
+            bit_data: raw.get(start..end).unwrap_or(&[]),
+        })
     }
 
-    /// Raw bytes, always zero-copy.
+    /// Declared number of bits in this `Dn` field.
+    #[inline]
+    pub fn bit_count(&self) -> u16 {
+        self.bit_count
+    }
+
+    /// Raw packed bytes, always zero-copy.
     #[inline]
     pub fn as_bytes(&self) -> &'a [u8] {
-        self.0
+        self.bit_data
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.bit_data.is_empty()
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.bit_data.len()
     }
 
     /// Allocating; reproduces the owned `Dn` (byte copy) semantics used by
     /// `StdfRecord`, so results match the eager parser.
     pub fn to_owned(&self) -> Dn {
-        self.0.to_vec()
+        Dn {
+            bit_count: self.bit_count,
+            bit_data: self.bit_data.to_vec(),
+        }
     }
 }
 

--- a/src/stdf_codec/primitives.rs
+++ b/src/stdf_codec/primitives.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use serde::Serialize;
 
 // Common Type
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ByteOrder {
     LittleEndian,

--- a/src/stdf_file.rs
+++ b/src/stdf_file.rs
@@ -391,7 +391,7 @@ impl<R: BufRead + Seek> Iterator for RecordIter<'_, R> {
             return Some(Err(StdfError::new(StdfErrorKind::Io, io_e.to_string())));
         }
 
-        let mut rec = StdfRecord::new_from_header(header);
+        let mut rec = StdfRecord::new_from_header(&header);
         rec.read_from_bytes(&self.buffer[..len], &self.inner.endianness);
         Some(Ok(rec))
     }

--- a/tests/stdf_file_tests.rs
+++ b/tests/stdf_file_tests.rs
@@ -440,7 +440,7 @@ fn rawdata_element_conversions() {
 
         // type checks
         assert!(raw.is_type(code));
-        assert!(!raw.is_type(REC_INVALID));
+        assert!(!raw.is_type(REC_UNKNOWN));
         assert_eq!(raw.header.get_type(), code);
 
         // non-consuming conversions
@@ -535,7 +535,7 @@ fn rawdata_element_view_conversions() {
 
         // type checks
         assert!(raw.is_type(code));
-        assert!(!raw.is_type(REC_INVALID));
+        assert!(!raw.is_type(REC_UNKNOWN));
 
         // borrowed conversions
         let rec: StdfRecord = (&raw).into();

--- a/tests/stdf_record_tests.rs
+++ b/tests/stdf_record_tests.rs
@@ -1680,9 +1680,9 @@ fn record_kx_sn_ref_test() {
 }
 
 // `KxCfRef` (an STR `user_txt` array): fixed-width `f`-byte elements, no
-// length prefix, same decoding rule.
+// length prefix, same decoding rule. Also covers `DnRef` via `mask_map`/`fal_map`.
 #[test]
-fn record_kx_cf_ref_test() {
+fn record_kx_cf_ref_and_dn_ref_test() {
     use std::borrow::Cow;
 
     let order = ByteOrder::LittleEndian;
@@ -1700,8 +1700,8 @@ fn record_kx_cf_ref_test() {
     cn(&mut raw, ""); // rslt_txt
     raw.push(0); // z_val
     raw.push(0); // fmu_flg
-    dn(&mut raw, 0, &[]); // mask_map
-    dn(&mut raw, 0, &[]); // fal_map
+    dn(&mut raw, 8, &[0xFF]); // mask_map
+    dn(&mut raw, 4, &[0x0F]); // fal_map
     raw.extend_from_slice(&0u64.to_le_bytes()); // cyc_cnt_t
     raw.extend_from_slice(&0u32.to_le_bytes()); // totf_cnt
     raw.extend_from_slice(&0u32.to_le_bytes()); // totl_cnt
@@ -1740,6 +1740,35 @@ fn record_kx_cf_ref_test() {
     r.read_from_bytes(&raw, &order);
     let v = STRView::new(&raw, &order);
 
+    // DnRef exposes both the declared bit count and the packed bytes.
+    let mask_map = v.mask_map();
+    assert_eq!(mask_map.bit_count(), 8);
+    assert_eq!(mask_map.as_bytes(), &[0xFF][..]);
+    assert_eq!(mask_map.len(), 1);
+    assert!(!mask_map.is_empty());
+    assert_eq!(mask_map.to_owned(), r.mask_map);
+    assert_eq!(
+        mask_map.to_owned(),
+        Dn {
+            bit_count: 8,
+            bit_data: vec![0xFF],
+        }
+    );
+
+    let fal_map = v.fal_map();
+    assert_eq!(fal_map.bit_count(), 4);
+    assert_eq!(fal_map.as_bytes(), &[0x0F][..]);
+    assert_eq!(fal_map.len(), 1);
+    assert!(!fal_map.is_empty());
+    assert_eq!(fal_map.to_owned(), r.fal_map);
+    assert_eq!(
+        fal_map.to_owned(),
+        Dn {
+            bit_count: 4,
+            bit_data: vec![0x0F],
+        }
+    );
+
     let kx = v.user_txt();
     assert_eq!(kx.len(), 3);
     assert!(matches!(&kx.get_str(0).unwrap(), Cow::Borrowed(_)));
@@ -1755,4 +1784,69 @@ fn record_kx_cf_ref_test() {
         seen.push(s);
     }
     assert_eq!(seen, kx.as_vec());
+}
+
+// Reserved/unknown records must preserve the header fields and byte order so a
+// future writer can reconstruct the original record header from `raw_data.len()`.
+#[test]
+fn reserved_unknown_record_preserves_header_and_order() {
+    let order = ByteOrder::BigEndian;
+
+    // Reserved record: typ=180, sub=10, body = [0xAA, 0xBB, 0xCC]
+    let mut reserved_raw = Vec::new();
+    reserved_raw.extend_from_slice(&3u16.to_be_bytes());
+    reserved_raw.push(180);
+    reserved_raw.push(10);
+    reserved_raw.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+
+    let rec = StdfRecord::read_from_bytes_with_header(&reserved_raw, &order).unwrap();
+    match rec {
+        StdfRecord::ReservedRec(r) => {
+            assert_eq!(r.typ, 180);
+            assert_eq!(r.sub, 10);
+            assert_eq!(r.byte_order, order);
+            assert_eq!(r.raw_data, vec![0xAA, 0xBB, 0xCC]);
+        }
+        other => panic!("expected ReservedRec, got {other:?}"),
+    }
+
+    let view = StdfRecordView::read_from_bytes_with_header(&reserved_raw, &order).unwrap();
+    match view.to_owned() {
+        StdfRecord::ReservedRec(r) => {
+            assert_eq!(r.typ, 180);
+            assert_eq!(r.sub, 10);
+            assert_eq!(r.byte_order, order);
+            assert_eq!(r.raw_data, vec![0xAA, 0xBB, 0xCC]);
+        }
+        other => panic!("expected ReservedRec from view, got {other:?}"),
+    }
+
+    // Unknown record: typ=99, sub=7, body = [1, 2]
+    let mut unknown_raw = Vec::new();
+    unknown_raw.extend_from_slice(&2u16.to_be_bytes());
+    unknown_raw.push(99);
+    unknown_raw.push(7);
+    unknown_raw.extend_from_slice(&[1, 2]);
+
+    let rec = StdfRecord::read_from_bytes_with_header(&unknown_raw, &order).unwrap();
+    match rec {
+        StdfRecord::UnknownRec(r) => {
+            assert_eq!(r.typ, 99);
+            assert_eq!(r.sub, 7);
+            assert_eq!(r.byte_order, order);
+            assert_eq!(r.raw_data, vec![1, 2]);
+        }
+        other => panic!("expected UnknownRec, got {other:?}"),
+    }
+
+    let view = StdfRecordView::read_from_bytes_with_header(&unknown_raw, &order).unwrap();
+    match view.to_owned() {
+        StdfRecord::UnknownRec(r) => {
+            assert_eq!(r.typ, 99);
+            assert_eq!(r.sub, 7);
+            assert_eq!(r.byte_order, order);
+            assert_eq!(r.raw_data, vec![1, 2]);
+        }
+        other => panic!("expected UnknownRec from view, got {other:?}"),
+    }
 }


### PR DESCRIPTION
Prepare to implement STDF write feature, following changes are required and break current public APIs.

1. add `bit_count` to `Dn`.
2. add `typ`, `sub` and `byteOrder` to `ReservedRec`.
3. const code `REC_INVALID` is removed, replaced with `REC_UNKNOWN`.
4. enum `StdfRecord::InvalidRec` changes to `StdfRecord::UnknownRec`, use `ReservedRec` as enum data.
5. `StdfRecord::new_from_header` takes the reference of header.
6. bump version to `1.0.0`